### PR TITLE
Arreglar Modulo educativo

### DIFF
--- a/patitasbog-frontend/src/components/Education/CategoriesSection.jsx
+++ b/patitasbog-frontend/src/components/Education/CategoriesSection.jsx
@@ -7,25 +7,46 @@ const CategoriesSection = ({ selectedCategory, setSelectedCategory }) => {
       id: 'general',
       name: 'Consejos Generales',
       icon: '🏠',
-      description: 'Fundamentos básicos para cuidar tu mascota'
+      description: [
+                    'Identificación de mascotas',
+                    'Mantenimiento de fotos actualizadas',
+                    'Conocimiento del vecindario',
+                    'Red de contactos'
+                  ]
+
     },
     {
       id: 'prevention',
       name: 'Prevención',
       icon: '🛡️',
-      description: 'Evita que tu mascota se pierda'
+      description: [
+                    'Microchip obligatorio',
+                    'Collar con GPS',
+                    'Entrenamiento básico',
+                    'Rutinas establecidas'
+                  ]
     },
     {
-      id: 'search',
-      name: 'Búsqueda',
-      icon: '🔍',
-      description: 'Qué hacer si tu mascota se pierde'
-    },
+  id: 'search',
+  name: 'Búsqueda',
+  icon: '🔍',
+  description: [
+                  'Acción rápida',
+                  'Uso de redes sociales',
+                  'Carteles efectivos',
+                  'Búsqueda en diferentes horarios'
+              ]
+},
     {
       id: 'care',
       name: 'Cuidados',
       icon: '❤️',
-      description: 'Salud y bienestar de tu mascota'
+description: [
+                'Medicina preventiva',
+                'Alimentación balanceada',
+                'Ejercicio regular',
+                'Revisiones veterinarias'
+              ]
     }
   ];
 
@@ -49,7 +70,12 @@ const CategoriesSection = ({ selectedCategory, setSelectedCategory }) => {
           >
             <div className={styles.categoryIcon}>{category.icon}</div>
             <h3 className={styles.categoryTitle}>{category.name}</h3>
-            <p className={styles.categoryDescription}>{category.description}</p>
+            <div className={styles.categoryDescription}>
+              {category.description.map((tip, idx) => (
+                <p key={idx}>{tip}</p>
+              ))}
+            </div>
+
             <div className={styles.categoryArrow}>→</div>
           </div>
         ))}

--- a/patitasbog-frontend/src/styles/Education.module.css
+++ b/patitasbog-frontend/src/styles/Education.module.css
@@ -236,11 +236,23 @@
 }
 
 .categoryDescription {
+  display: none;
   font-size: 0.9rem;
   color: inherit;
   opacity: 0.8;
   margin-bottom: var(--spacing-2);
 }
+
+.categoryDescription p {
+  margin-bottom: 0.6rem;      /* Espacio entre cada tip */
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.categoryCard:hover .categoryDescription {
+  display: block;
+}
+
 
 .categoryArrow {
   font-size: 1.5rem;


### PR DESCRIPTION
Se mejoró la visualización de los consejos (description) en las tarjetas de categorías del componente CategoriesSection. Originalmente, los consejos estaban definidos como un arreglo (array), pero se intentaban mostrar dentro de una sola etiqueta <p>, lo que generaba una visualización incorrecta (todo el texto junto o como [object Object]).

Para solucionarlo, se reemplazó el uso de <p>{category.description}</p> por un recorrido (.map) del arreglo description, generando un <p> separado para cada tip. Además, se agregó un pequeño margen inferior a cada párrafo desde CSS para mejorar el espaciado y la legibilidad.

Y tambien se añadieron pequeños tips